### PR TITLE
Reuse existing container

### DIFF
--- a/dev
+++ b/dev
@@ -39,6 +39,7 @@ docker run --name howtowhale-hub \
   -e CARINA_CLIENT_ID=$CARINA_DEV_CLIENT_ID \
   -e CARINA_CLIENT_SECRET=$CARINA_DEV_CLIENT_SECRET \
   -e DOCKER_HOST=https://${DOCKER_HOST#tcp://} \
+  -e JPY_COOKIE_SECRET=$JPY_COOKIE_SECRET \
   carolynvs/howtowhale-hub:$VERSION
 
 echo "### Spin up the proxy"

--- a/howtowhale-hub/lib/jupyterhub_carina/CarinaSpawner.py
+++ b/howtowhale-hub/lib/jupyterhub_carina/CarinaSpawner.py
@@ -67,7 +67,6 @@ class CarinaSpawner(DockerSpawner):
 
             yield self.create_cluster()
             yield self.download_cluster_credentials()
-            yield self.pull_image()
 
             self.log.info("Starting notebook container for {}...".format(self.user.name))
             extra_env = {
@@ -187,8 +186,3 @@ class CarinaSpawner(DockerSpawner):
     def get_user_credentials_dir(self):
         credentials_dir = "/root/.carina/clusters/{}/{}".format(self.user.name, self.cluster_name)
         return credentials_dir
-    @gen.coroutine
-    def pull_image(self):
-        self.log.debug("Starting to pull {} image to the {} cluster...".format(self.container_image, self.user.name))
-        yield self.docker("pull", self.container_image)
-        self.log.debug("Finished pulling {} image to the {} cluster...".format(self.container_image, self.user.name))

--- a/howtowhale-hub/lib/jupyterhub_carina/CarinaSpawner.py
+++ b/howtowhale-hub/lib/jupyterhub_carina/CarinaSpawner.py
@@ -81,13 +81,6 @@ class CarinaSpawner(DockerSpawner):
 
             yield super().start(extra_create_kwargs=extra_create_kwargs)
 
-            container = yield self.get_container()
-            if container is not None:
-                node_name = container['Node']['IP']
-                self.user.server.ip = node_name
-                self.log.info("{} was started on {} ({}:{})".format(
-                    self.container_name, node_name, self.user.server.ip, self.user.server.port))
-
             self.log.debug('Startup for {} is complete!'.format(self.user.name))
         except Exception as e:
             self.log.error('Startup for {} failed!'.format(self.user.name))

--- a/howtowhale-hub/lib/jupyterhub_carina/CarinaSpawner.py
+++ b/howtowhale-hub/lib/jupyterhub_carina/CarinaSpawner.py
@@ -88,30 +88,6 @@ class CarinaSpawner(DockerSpawner):
             raise
 
     @gen.coroutine
-    def poll(self):
-        """Check for my id in `docker ps`"""
-        container = yield self.get_container()
-        if not container:
-            self.log.info("Notebook container for {} was not found".format(self.user.name))
-            return ""
-
-        container_state = container['State']
-        self.log.debug(
-            "Container %s status: %s",
-            self.container_id[:7],
-            pprint.pformat(container_state),
-        )
-
-        if container_state["Running"]:
-            return None
-        else:
-            return (
-                "ExitCode={ExitCode}, "
-                "Error='{Error}', "
-                "FinishedAt={FinishedAt}".format(**container_state)
-            )
-
-    @gen.coroutine
     def create_cluster(self):
         """
         Create a Carina cluster.

--- a/howtowhale-hub/lib/jupyterhub_carina/CarinaSpawner.py
+++ b/howtowhale-hub/lib/jupyterhub_carina/CarinaSpawner.py
@@ -120,6 +120,9 @@ class CarinaSpawner(DockerSpawner):
         The API will return 404 if the cluster isn't available yet,
         in which case the reqeust should be retried
         """
+        credentials_dir = self.get_user_credentials_dir()
+        if os.path.exists(credentials_dir):
+            return
 
         self.log.info("Downloading {} cluster credentials for {}...".format(self.cluster_name, self.user.name))
 

--- a/howtowhale-hub/lib/jupyterhub_carina/CarinaSpawner.py
+++ b/howtowhale-hub/lib/jupyterhub_carina/CarinaSpawner.py
@@ -54,23 +54,10 @@ class CarinaSpawner(DockerSpawner):
 
     @gen.coroutine
     def get_container(self):
-        if not self.container_id:
+        if not os.path.exists(self.get_user_credentials_dir()):
             return None
 
-        self.log.debug("Getting container: %s", self.container_id)
-        try:
-            container = yield self.docker(
-                'inspect_container', self.container_id
-            )
-            self.container_id = container['Id']
-        except APIError as e:
-            if e.response.status_code == 404:
-                self.log.info("Container '%s' is gone", self.container_id)
-                container = None
-                # my container is gone, forget my id
-                self.container_id = ''
-            else:
-                raise
+        container = yield super().get_container()
         return container
 
     @gen.coroutine


### PR DESCRIPTION
If for any reason (e.g. hub restart) the hub forgets about the user server, attempt to reuse the existing container.

Fixes #2
