### PR TITLE
fix links swapped for carina and jupyter

### DIFF
--- a/howtowhale-web/html/index.html
+++ b/howtowhale-web/html/index.html
@@ -114,8 +114,8 @@
         So is it magic? Nope, just massively abusing cool stuff for fun and profit.
       </p>
       <div class="platform">
-        <a href="http://getcarina.com"><img src="/img/jupyter.png" alt="Jupyter Logo" /></a>
-        <a href="http://jupyter.org"><img src="/img/carina.png" alt="Carina by Rackspace Logo" /></a>
+        <a href="http://jupyter.org"><img src="/img/jupyter.png" alt="Jupyter Logo" /></a>
+        <a href="http://getcarina.com"><img src="/img/carina.png" alt="Carina by Rackspace Logo" /></a>
       </div>
 
       <h2 id="evil-intentions">Why How to Whale?</h2>


### PR DESCRIPTION
Jupyter logo image was a link to Carina, and Carina logo was a link to Jupyter.

This PR fixes that.
